### PR TITLE
Ignore LaTeX compilation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*.pdf
+*.toc
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.run.xml
+*.synctex.gz


### PR DESCRIPTION
This adds a gitignore file to prevent LaTeX compilation files from being tracked.